### PR TITLE
[RFC] Change `Service` associated `Request` type to a type parameter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ log = "0.4.1"
 tokio = "0.1.6"
 tokio-fs = "0.1.2"
 tokio-io = "0.1.7"
-tower-service = "0.1.0"
+tower-service = { git = "https://github.com/tower-rs/tower", branch = "eliza/generic-service" }
 
 # Parsing params
 atoi = "0.2.3"

--- a/src/middleware/chain.rs
+++ b/src/middleware/chain.rs
@@ -22,12 +22,11 @@ impl<Inner, Outer> Chain<Inner, Outer> {
     }
 }
 
-impl<S, Inner, Outer> Middleware<S> for Chain<Inner, Outer>
-where S: Service,
-      Inner: Middleware<S>,
-      Outer: Middleware<Inner::Service>,
+impl<S, Inner, Outer, R> Middleware<S, R> for Chain<Inner, Outer>
+where S: Service<R>,
+      Inner: Middleware<S, R>,
+      Outer: Middleware<Inner::Service, R>,
 {
-    type Request = Outer::Request;
     type Response = Outer::Response;
     type Error = Outer::Error;
     type Service = Outer::Service;

--- a/src/middleware/cors/middleware.rs
+++ b/src/middleware/cors/middleware.rs
@@ -2,7 +2,7 @@ use super::{Config, CorsService};
 use middleware::Middleware;
 
 use http;
-use util::http::HttpService;
+use util::{BufStream, http::HttpService};
 
 use std::sync::Arc;
 
@@ -21,6 +21,7 @@ impl CorsMiddleware {
 impl<S, R> Middleware<S, http::Request<R>> for CorsMiddleware
 where
     S: HttpService<R>,
+    R: BufStream,
 {
     type Response = http::Response<Option<S::ResponseBody>>;
     type Error = S::Error;

--- a/src/middleware/cors/middleware.rs
+++ b/src/middleware/cors/middleware.rs
@@ -18,11 +18,10 @@ impl CorsMiddleware {
     }
 }
 
-impl<S> Middleware<S> for CorsMiddleware
+impl<S, R> Middleware<S, http::Request<R>> for CorsMiddleware
 where
-    S: HttpService,
+    S: HttpService<R>,
 {
-    type Request = http::Request<S::RequestBody>;
     type Response = http::Response<Option<S::ResponseBody>>;
     type Error = S::Error;
     type Service = CorsService<S>;

--- a/src/middleware/cors/service.rs
+++ b/src/middleware/cors/service.rs
@@ -3,7 +3,10 @@ use super::{Config, CorsResource};
 use futures::{Async, Future, Poll};
 use http::{self, HeaderMap, Request, Response, StatusCode};
 use tower_service::Service;
-use util::http::HttpService;
+use util::{
+    BufStream,
+    http::HttpService,
+};
 
 use std::sync::Arc;
 
@@ -19,11 +22,11 @@ impl<S> CorsService<S> {
     }
 }
 
-impl<S> Service for CorsService<S>
+impl<S, R> Service<Request<R>> for CorsService<S>
 where
-    S: HttpService,
+    S: HttpService<R>,
+    R: BufStream,
 {
-    type Request = Request<S::RequestBody>;
     type Response = Response<Option<S::ResponseBody>>;
     type Error = S::Error;
     type Future = CorsFuture<S::Future>;
@@ -32,7 +35,7 @@ where
         self.inner.poll_http_ready()
     }
 
-    fn call(&mut self, request: Self::Request) -> Self::Future {
+    fn call(&mut self, request: Request<R>) -> Self::Future {
         let inner = match self.config.process_request(&request) {
             Ok(CorsResource::Preflight(headers)) => CorsFutureInner::Handled(Some(headers)),
             Ok(CorsResource::Simple(headers)) => {
@@ -125,8 +128,7 @@ mod test {
         requests: Vec<http::Request<DontCare>>,
     }
 
-    impl Service for MockService {
-        type Request = http::Request<DontCare>;
+    impl Service<http::Request<DontCare>> for MockService {
         type Response = http::Response<DontCare>;
         type Error = TestError;
         type Future = FutureResult<Self::Response, Self::Error>;
@@ -136,7 +138,7 @@ mod test {
             Ok(Async::Ready(()))
         }
 
-        fn call(&mut self, request: Self::Request) -> Self::Future {
+        fn call(&mut self, request: http::Request<DontCare>) -> Self::Future {
             self.requests.push(request);
             future::ok(http::Response::new(buf_stream::empty()))
         }

--- a/src/middleware/identity.rs
+++ b/src/middleware/identity.rs
@@ -19,8 +19,7 @@ impl Identity {
 }
 
 /// Decorates a `Service`, transforming either the request or the response.
-impl<S: Service> Middleware<S> for Identity {
-    type Request = S::Request;
+impl<S: Service<R>, R> Middleware<S, R> for Identity {
     type Response = S::Response;
     type Error = S::Error;
     type Service = S;

--- a/src/middleware/log/middleware.rs
+++ b/src/middleware/log/middleware.rs
@@ -17,7 +17,7 @@ impl LogMiddleware {
     }
 }
 
-impl<S, RequestBody, ResponseBody> Middleware<S, RequestBody> for LogMiddleware
+impl<S, RequestBody, ResponseBody> Middleware<S, http::Request<RequestBody>> for LogMiddleware
 where S: Service<http::Request<RequestBody>,
                 Response = http::Response<ResponseBody>>,
       S::Error: ::std::error::Error,

--- a/src/middleware/log/middleware.rs
+++ b/src/middleware/log/middleware.rs
@@ -17,12 +17,11 @@ impl LogMiddleware {
     }
 }
 
-impl<S, RequestBody, ResponseBody> Middleware<S> for LogMiddleware
-where S: Service<Request = http::Request<RequestBody>,
+impl<S, RequestBody, ResponseBody> Middleware<S, RequestBody> for LogMiddleware
+where S: Service<http::Request<RequestBody>,
                 Response = http::Response<ResponseBody>>,
       S::Error: ::std::error::Error,
 {
-    type Request = http::Request<RequestBody>;
     type Response = http::Response<ResponseBody>;
     type Error = S::Error;
     type Service = LogService<S>;

--- a/src/middleware/log/service.rs
+++ b/src/middleware/log/service.rs
@@ -31,12 +31,11 @@ impl<S> LogService<S> {
     }
 }
 
-impl<S, RequestBody, ResponseBody> Service for LogService<S>
-where S: Service<Request = http::Request<RequestBody>,
+impl<S, RequestBody, ResponseBody> Service<http::Request<RequestBody>> for LogService<S>
+where S: Service<http::Request<RequestBody>,
                 Response = http::Response<ResponseBody>>,
       S::Error: ::std::error::Error,
 {
-    type Request = S::Request;
     type Response = S::Response;
     type Error = S::Error;
     type Future = ResponseFuture<S::Future>;
@@ -45,7 +44,7 @@ where S: Service<Request = http::Request<RequestBody>,
         self.inner.poll_ready()
     }
 
-    fn call(&mut self, request: Self::Request) -> Self::Future {
+    fn call(&mut self, request: http::Request<RequestBody>) -> Self::Future {
         let method = request.method().clone();
         let path = request.uri().path_and_query().map(|p| p.clone());
         let version = request.version();

--- a/src/middleware/middleware.rs
+++ b/src/middleware/middleware.rs
@@ -77,10 +77,7 @@ use tower_service::Service;
 /// The above log implementation is decoupled from the underlying protocol and
 /// is also decoupled from client or server concerns. In other words, the same
 /// log middleware could be used in either a client or a server.
-pub trait Middleware<S> {
-    /// The wrapped service request type
-    type Request;
-
+pub trait Middleware<S, R> {
     /// The wrapped service response type
     type Response;
 
@@ -88,7 +85,7 @@ pub trait Middleware<S> {
     type Error;
 
     /// The wrapped service
-    type Service: Service<Request = Self::Request,
+    type Service: Service<R,
                          Response = Self::Response,
                             Error = Self::Error>;
 
@@ -101,7 +98,7 @@ pub trait Middleware<S> {
     ///
     /// This defines a middleware stack.
     fn chain<T>(self, middleware: T) -> Chain<Self, T>
-    where T: Middleware<Self::Service>,
+    where T: Middleware<Self::Service, R>,
           Self: Sized,
     {
         Chain::new(self, middleware)

--- a/src/middleware/middleware.rs
+++ b/src/middleware/middleware.rs
@@ -29,12 +29,11 @@ use tower_service::Service;
 ///     target: &'static str,
 /// }
 ///
-/// impl<S> Middleware<S> for LogMiddleware
+/// impl<S, R> Middleware<S, R> for LogMiddleware
 /// where
-///     S: Service,
-///     S::Request: fmt::Debug,
+///     S: Service<R>,
+///     R: fmt::Debug,
 /// {
-///     type Request = S::Request;
 ///     type Response = S::Response;
 ///     type Error = S::Error;
 ///     type Service = LogService<S>;
@@ -53,12 +52,11 @@ use tower_service::Service;
 ///     service: S,
 /// }
 ///
-/// impl<S> Service for LogService<S>
+/// impl<S, R> Service<R> for LogService<S>
 /// where
-///     S: Service,
-///     S::Request: fmt::Debug,
+///     S: Service<R>,
+///     R: fmt::Debug,
 /// {
-///     type Request = S::Request;
 ///     type Response = S::Response;
 ///     type Error = S::Error;
 ///     type Future = S::Future;
@@ -67,7 +65,7 @@ use tower_service::Service;
 ///         self.service.poll_ready()
 ///     }
 ///
-///     fn call(&mut self, request: Self::Request) -> Self::Future {
+///     fn call(&mut self, request: R) -> Self::Future {
 ///         info!(target: self.target, "request = {:?}", request);
 ///         self.service.call(request)
 ///     }

--- a/src/routing/service.rs
+++ b/src/routing/service.rs
@@ -88,11 +88,10 @@ where T: Resource,
     }
 }
 
-impl<T, U> Service for RoutedService<T, U>
+impl<T, U> Service<http::Request<T::RequestBody>> for RoutedService<T, U>
 where T: Resource,
       U: Catch,
 {
-    type Request = http::Request<T::RequestBody>;
     type Response = <Self::Future as Future>::Item;
     type Error = Error;
     type Future = RoutedResponse<T::Future, U>;
@@ -102,7 +101,7 @@ where T: Resource,
         Ok(().into())
     }
 
-    fn call(&mut self, request: Self::Request) -> Self::Future {
+    fn call(&mut self, request: http::Request<T::RequestBody>) -> Self::Future {
         // TODO: Use the body
         let (head, body) = request.into_parts();
         let request = http::Request::from_parts(head, ());

--- a/src/service/builder.rs
+++ b/src/service/builder.rs
@@ -319,7 +319,7 @@ impl<T, C, M> ServiceBuilder<T, C, M> {
     pub fn build_new_service<RequestBody>(self) -> NewWebService<T::Resource, C::Catch, M>
     where T: IntoResource<DefaultSerializer, RequestBody>,
           C: IntoCatch<DefaultSerializer>,
-          M: HttpMiddleware<RoutedService<T::Resource, C::Catch>>,
+          M: HttpMiddleware<RoutedService<T::Resource, C::Catch>, RequestBody>,
           RequestBody: BufStream,
     {
         // Build the routes
@@ -367,9 +367,9 @@ impl<T, C, M> ServiceBuilder<T, C, M> {
     where T: IntoResource<DefaultSerializer, ::run::LiftReqBody>,
           C: IntoCatch<DefaultSerializer> + Send + 'static,
           C::Catch: Send,
-          M: HttpMiddleware<RoutedService<T::Resource, C::Catch>, RequestBody = ::run::LiftReqBody> + Send + 'static,
+          M: HttpMiddleware<RoutedService<T::Resource, C::Catch>, ::run::LiftReqBody> + Send + 'static,
           M::Service: Send,
-          <M::Service as HttpService>::Future: Send,
+          <M::Service as HttpService<::run::LiftReqBody>>::Future: Send,
           M::ResponseBody: Send,
           <M::ResponseBody as BufStream>::Item: Send,
           T::Resource: Send + 'static,

--- a/src/service/new_service.rs
+++ b/src/service/new_service.rs
@@ -1,8 +1,10 @@
 use error::Catch;
 use routing::{Resource, RoutedService};
 use service::WebService;
-use util::Never;
-use util::http::{HttpMiddleware};
+use util::{
+    BufStream, Never,
+    http::{HttpMiddleware},
+};
 
 use futures::future::{self, FutureResult};
 use http;
@@ -29,7 +31,6 @@ impl<T, U, M> NewWebService<T, U, M>
 where
     T: Resource,
     U: Catch,
-    M: HttpMiddleware<RoutedService<T, U>>,
 {
     /// Create a new `NewWebService` instance.
     pub(crate) fn new(service: RoutedService<T, U>, middleware: M) -> Self {
@@ -40,16 +41,16 @@ where
     }
 }
 
-impl<T, U, M> NewService for NewWebService<T, U, M>
+impl<T, U, M, B> NewService<http::Request<B>> for NewWebService<T, U, M>
 where
     T: Resource,
     U: Catch,
-    M: HttpMiddleware<RoutedService<T, U>>,
+    M: HttpMiddleware<RoutedService<T, U>, B>,
+    B: BufStream,
 {
-    type Request = http::Request<M::RequestBody>;
     type Response = http::Response<M::ResponseBody>;
     type Error = M::Error;
-    type Service = WebService<T, U, M>;
+    type Service = WebService<T, U, M, B>;
     type InitError = Never;
     type Future = FutureResult<Self::Service, Self::InitError>;
 

--- a/src/util/http/middleware.rs
+++ b/src/util/http/middleware.rs
@@ -11,9 +11,7 @@ use http::{Request, Response};
 ///
 /// Using `HttpMiddleware` in where bounds is easier than trying to use `Middleware`
 /// directly.
-pub trait HttpMiddleware<S>: sealed::Sealed<S> {
-    /// The HTTP request body handled by the wrapped service.
-    type RequestBody: BufStream;
+pub trait HttpMiddleware<S, RequestBody: BufStream>: sealed::Sealed<S, RequestBody> {
 
     /// The HTTP response body returned by the wrapped service.
     type ResponseBody: BufStream;
@@ -22,7 +20,7 @@ pub trait HttpMiddleware<S>: sealed::Sealed<S> {
     type Error;
 
     /// The wrapped service.
-    type Service: HttpService<RequestBody = Self::RequestBody,
+    type Service: HttpService<RequestBody,
                              ResponseBody = Self::ResponseBody,
                                     Error = Self::Error>;
 
@@ -31,13 +29,12 @@ pub trait HttpMiddleware<S>: sealed::Sealed<S> {
     fn wrap_http(&self, inner: S) -> Self::Service;
 }
 
-impl<T, S, B1, B2> HttpMiddleware<S> for T
-where T: Middleware<S, Request = Request<B1>,
+impl<T, S, B1, B2> HttpMiddleware<S, B1> for T
+where T: Middleware<S, Request<B1>,
                       Response = Response<B2>>,
       B1: BufStream,
       B2: BufStream,
 {
-    type RequestBody = B1;
     type ResponseBody = B2;
     type Error = T::Error;
     type Service = T::Service;
@@ -47,13 +44,13 @@ where T: Middleware<S, Request = Request<B1>,
     }
 }
 
-impl<T, S, B1, B2> sealed::Sealed<S> for T
-where T: Middleware<S, Request = Request<B1>,
+impl<T, S, B1, B2> sealed::Sealed<S, B1> for T
+where T: Middleware<S, Request<B1>,
                       Response = Response<B2>>,
       B1: BufStream,
       B2: BufStream,
 {}
 
 mod sealed {
-    pub trait Sealed<S> {}
+    pub trait Sealed<S, B1> {}
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -3,7 +3,10 @@
 pub extern crate futures;
 extern crate tower_service;
 
-pub use tower_web::util::http::HttpService;
+pub use tower_web::util::{
+    http::HttpService,
+    BufStream,
+};
 
 use tower_web::ServiceBuilder;
 use tower_web::response::DefaultSerializer;
@@ -107,7 +110,7 @@ macro_rules! assert_body {
     }}
 }
 
-pub fn service<U>(resource: U) -> impl TestHttpService<RequestBody = String>
+pub fn service<U>(resource: U) -> impl TestHttpService<String>
 where U: IntoResource<DefaultSerializer, String>,
 {
     use self::futures::Future;
@@ -120,11 +123,11 @@ where U: IntoResource<DefaultSerializer, String>,
         .wait().unwrap()
 }
 
-pub trait TestHttpService: HttpService {
-    fn call_unwrap(&mut self, request: http::Request<Self::RequestBody>) -> http::Response<Self::ResponseBody> {
+pub trait TestHttpService<B: BufStream>: HttpService<B> {
+    fn call_unwrap(&mut self, request: http::Request<B>) -> http::Response<Self::ResponseBody> {
         self.call_http(request).wait().ok().unwrap()
     }
 }
 
-impl<T: HttpService> TestHttpService for T {
+impl<T: HttpService<B>, B: BufStream> TestHttpService<B> for T {
 }


### PR DESCRIPTION
As described in tower-rs/tower#99, this tracks the prototype `tower-rs` change (hawkw/tower#1) that makes `Service::Request` into a type parameter, rather than an associated type.

This PR is not necessarily intended to be merged, but is opened to allow the changes to be discussed and reviewed more easily.